### PR TITLE
Small change to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,5 @@ compile the source file and install as a ubuntu application:
 $ make && make install
 ```
 
-then you can find the restorer in launcher by the name 'evince-restorer'.
+then you can find the restorer in launcher by the name 'Restore Document Viewer
+Sessions'.


### PR DESCRIPTION
I don't see 'evince-restorer' in the launcher. It should be 'Restore Document Viewer Sessions' instead.