### PR TITLE
Fix bug: failure to open pdf with single quote in the title

### DIFF
--- a/evince-restorer.cpp
+++ b/evince-restorer.cpp
@@ -109,6 +109,7 @@ void launchEvince(std::string pdfs) {
         system("evince &");
         std::cout << "empty session" << std::endl;
     } else {
+        replaceAll(pdfs, "\'", "\'\"\'\"\'");
         replaceAll(pdfs, "\n", "\' & evince \'");
         pdfs = "evince \'" + pdfs + "\' &";
         std::cout << "calling:\n" << pdfs << std::endl;


### PR DESCRIPTION
There are other solutions you might like https://stackoverflow.com/questions/1250079/how-to-escape-single-quotes-within-single-quoted-strings .